### PR TITLE
Throttle loadEvents calls

### DIFF
--- a/google-style-calendar-card.js
+++ b/google-style-calendar-card.js
@@ -19,9 +19,17 @@ class GoogleStyleCalendarCard extends HTMLElement {
     return 10;
   }
 
+  connectedCallback() {
+    this._lastEventLoad = 0;
+  }
+
   set hass(hass) {
     this._hass = hass;
-    this.loadEvents();
+    const now = Date.now();
+    if (!this._lastEventLoad || now - this._lastEventLoad > 60 * 1000) {
+      this._lastEventLoad = now;
+      this.loadEvents();
+    }
   }
 
   async loadEvents() {


### PR DESCRIPTION
## Summary
- throttle `loadEvents` calls in `set hass`
- initialize last event load timestamp in `connectedCallback`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865525929708324b4a263256f1d034d